### PR TITLE
update fedora up-down script paths

### DIFF
--- a/source/howtos/vpn_config.rst
+++ b/source/howtos/vpn_config.rst
@@ -133,8 +133,8 @@ Procedure:
     down /etc/openvpn/down.sh
 
     # For Fedora:
-    up /usr/share/doc/openvpn-2.1.1/contrib/pull-resolv-conf/client.up
-    down /usr/share/doc/openvpn-2.1.1/contrib/pull-resolv-conf/client.down
+    up /usr/share/doc/openvpn/contrib/pull-resolv-conf/client.up
+    down /usr/share/doc/openvpn/contrib/pull-resolv-conf/client.down
 
 - Run OpenVPN: **openvpn /etc/openvpn/openvpn.conf**
 - Check connection:


### PR DESCRIPTION
The openvpn package dropped the version off of `/usr/share/doc/openvpn-<version>/`.