### PR TITLE
Remove any mention of compression configuration for VPN

### DIFF
--- a/source/howtos/vpn_config.rst
+++ b/source/howtos/vpn_config.rst
@@ -150,6 +150,8 @@ Troubleshooting
 The version of OpenVPN we are running is incompatible with OpenVPN client v2.4+ on OS X.
 If you are running OS X, please use OpenVPN v2.3 to connect to the VPN.
 
+Disabling LZO compression may help on older OpenVPN instances.
+
 Installation
 ~~~~~~~~~~~~
 Download and install Tunnelblick from the project's downloads_ page.

--- a/source/howtos/vpn_config.rst
+++ b/source/howtos/vpn_config.rst
@@ -18,7 +18,6 @@ Settings:
 - server: **vpn.osuosl.org:1194**
 - type: **Certificate (TLS)**
 - protocol: **UDP**
-- compression: **None** (Note this changed on 08/18/10 - previously LZO was used)
 - device type: **TUN**
 
 
@@ -47,7 +46,6 @@ Procedure:
   - CA Certificate:  **ca.crt**
   - Private Key: **<username>.key**
   - Private Key Password: **<password>** (if applicable)
-  - Advanced->Make sure 'Use LZO data compression' is **unchecked**
   - IPv4 Settings->Routes...->Use this connection only for resources on its
     network: **✔** (if unchecked, all network traffic is routed through the VPN)
 - Apply
@@ -91,7 +89,6 @@ Procedure:
     client                         # Client mode
     dev tun                        # Create a TUN device (not TAP)
     proto udp                      # Use UDP (not TCP)
-    #comp-lzo                      # Don't enable LZO compression
 
     remote vpn.osuosl.org 1194  # Server settings
     remote-cert-tls server         # Use TLS to check server identity


### PR DESCRIPTION
The default compression settings in OpenVPN will work on our firewall. Since setting this option is optional, this PR removes any mention of compression since it doesn't need to be configured.

This also adds a small bit of text in the troubleshooting section in case this effects older OpenVPN instances.