### PR TITLE
note about default security group policy

### DIFF
--- a/source/openstack/creating_instances.rst
+++ b/source/openstack/creating_instances.rst
@@ -62,6 +62,9 @@ the virtual machine. Generally the default security group should be all you need
 groups on as needed. You can also check what rules are set by clicking on the ">" icon next to the group. Now click
 "Next" or "Key Pair".
 
+.. important:: The default security group allows no traffic in. If you want to access your instance from the outside,
+               you will need to add rules to allow traffic.
+
 .. image:: /_static/images/openstack-instance1-security-groups.png
 
 Select key pair


### PR DESCRIPTION
I was bitten by this when creating a new instance: I misread the rules in the default security group and (wrongly) thought they were allowing traffic. I couldn't figure out what the problem was with my setup until I added an allow rule. It seems important to mention here that this will happen to people if they leave the default configuration on.