### PR TITLE
Add page to wiki to help people with IPQoS scp issue

### DIFF
--- a/source/howtos/ssh_ip_qos_fix.rst
+++ b/source/howtos/ssh_ip_qos_fix.rst
@@ -1,0 +1,24 @@
+Fixing Slow SSH Speeds With IPQoS
+==========================
+
+Why?
+----
+
+The Differentiated Services Code Point (DSCP_) field in an IP header is for
+classifying network data and providing Quality of Service (QoS). `The default
+SSH DSCP setting for non-interactive sessions`__ is ``CS1``. Within the OSL network,
+``CS1`` packets are dropped very frequently, thus resulting in poor performance
+when SCPing.
+
+How?
+----
+
+The poor performance when using SCP or rsync over secure shell can be remedied
+by adding ``-o IPQoS=throughput`` to your scp or rsync command. Another more
+permanent fix would be to add this to your ssh config::
+
+    Host *
+      IPQoS=throughput
+
+.. _DSCP: https://en.wikipedia.org/wiki/Differentiated_services
+.. __:    https://man7.org/linux/man-pages/man5/ssh_config.5.html

--- a/source/howtos/ssh_ip_qos_fix.rst
+++ b/source/howtos/ssh_ip_qos_fix.rst
@@ -4,18 +4,15 @@ Fixing Slow SSH Speeds With IPQoS
 Why?
 ----
 
-The Differentiated Services Code Point (DSCP_) field in an IP header is for
-classifying network data and providing Quality of Service (QoS). `The default
-SSH DSCP setting for non-interactive sessions`__ is ``CS1``. Within the OSL network,
-``CS1`` packets are dropped very frequently, thus resulting in poor performance
-when SCPing.
+The Differentiated Services Code Point (DSCP_) field in an IP header is for classifying network data and providing
+Quality of Service (QoS). `The default SSH DSCP setting for non-interactive sessions`__ is ``CS1``. Within the OSL
+network, ``CS1`` packets are dropped very frequently, thus resulting in poor performance when SCPing.
 
 How?
 ----
 
-The poor performance when using SCP or rsync over secure shell can be remedied
-by adding ``-o IPQoS=throughput`` to your scp or rsync command. Another more
-permanent fix would be to add this to your ssh config::
+The poor performance when using SCP or rsync over secure shell can be remedied by adding ``-o IPQoS=throughput`` to your
+scp or rsync command. Another more permanent fix would be to add this to your ssh config::
 
     Host *
       IPQoS=throughput

--- a/source/howtos/ssh_ip_qos_fix.rst
+++ b/source/howtos/ssh_ip_qos_fix.rst
@@ -6,7 +6,7 @@ Why?
 
 The Differentiated Services Code Point (DSCP_) field in an IP header is for classifying network data and providing
 Quality of Service (QoS). `The default SSH DSCP setting for non-interactive sessions`__ is ``CS1``. Within the OSL
-network, ``CS1`` packets are dropped very frequently, thus resulting in poor performance when SCPing.
+network, ``CS1`` packets might be dropped very frequently, thus resulting in poor performance when SCPing.
 
 How?
 ----


### PR DESCRIPTION
Adds a page to wiki explaining why speeds are so slow at times with scp, and how to fix it with either the ssh config file or the command line option.