### PR TITLE
Comment out html_theme_path to patch search

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -125,7 +125,7 @@ html_theme_options = {
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+#html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/source/conf.py
+++ b/source/conf.py
@@ -124,9 +124,6 @@ html_theme_options = {
     "analytics_id": "UA-537692-15",
 }
 
-# Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 #html_title = None


### PR DESCRIPTION
There is a documented issue where the deprecated variable, html_theme_path has caused the search feature to break. 

https://github.com/readthedocs/sphinx_rtd_theme/issues/1434#issuecomment-1472671651